### PR TITLE
feat: add statusBarContentDark option to ScreenshotStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Pass a `ScreenshotStyle` to `StoreScreenshotsTest` (class-level default) or to `
 | `mockupCameraDistance` | Perspective strength for the 3D tilt. Higher = flatter, lower = more dramatic. Default `12`. |
 | `showStatusBar` | Show/hide the status bar on phone, tablet, and Apple mockups. Default `true`. |
 | `statusBarClock` | Clock text in the status bar. Default `"12:00"`. |
+| `statusBarContentDark` | When `true`, the status bar clock and icons use a dark color instead of the default white so they stay visible on light mockup backgrounds. Default `false`. |
 | `edgeToEdge` | When `true` (default) the screen content is drawn full-bleed under the frame's status bar / notch, like a real edge-to-edge app. Set it to `false` to reserve the status bar's height so a standalone screen (rendered without the app's own window insets) doesn't have its top content — tabs, a top app bar — drawn under the status bar. Applies to phone and tablet frames and to `DeviceMockup(edgeToEdge = …)`; the Wear frame has no status bar strip. |
 | `titleFontFamily` / `descriptionFontFamily` | Font for the default title/description Text composables. |
 | `background` | Composable rendered behind everything. Overrides `backgroundColor`. |

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/DeviceMockup.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/DeviceMockup.kt
@@ -126,6 +126,7 @@ fun DeviceMockup(
     orientation: MockupOrientation = MockupOrientation.Portrait,
     showStatusBar: Boolean = true,
     statusBarClock: String = "12:00",
+    statusBarContentDark: Boolean = false,
     edgeToEdge: Boolean = true,
     rotationX: Float = 0f,
     rotationY: Float = 0f,
@@ -137,7 +138,7 @@ fun DeviceMockup(
     when (formFactor) {
         FormFactor.Phone -> {
             val (w, h) = orientSize(411.dp, 822.dp, orientation)
-            ScaledMockup(w, h, rotated) { PhoneBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
+            ScaledMockup(w, h, rotated) { PhoneBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
         }
         FormFactor.Wear ->
             WatchMockup(WatchShape.Round, rotated, content = content)
@@ -145,16 +146,16 @@ fun DeviceMockup(
             // Native size matches the form factor's own 16:10 qualifier (w600dp-h960dp) so the frame
             // and the content it measures reflect a real Android tablet, not a 4:3 iPad.
             val (w, h) = orientSize(600.dp, 960.dp, orientation)
-            ScaledMockup(w, h, rotated) { TabletBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
+            ScaledMockup(w, h, rotated) { TabletBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
         }
         FormFactor.Tablet10 -> {
             // 16:10 to match the w800dp-h1280dp qualifier (Pixel Tablet, Galaxy Tab, …).
             val (w, h) = orientSize(800.dp, 1280.dp, orientation)
-            ScaledMockup(w, h, rotated) { TabletBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
+            ScaledMockup(w, h, rotated) { TabletBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
         }
         FormFactor.AppleIPhone67 -> {
             val (w, h) = orientSize(430.dp, 932.dp, orientation)
-            ScaledMockup(w, h, rotated) { AppleBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
+            ScaledMockup(w, h, rotated) { AppleBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
         }
         FormFactor.GooglePlayFeatureGraphic -> error(
             "FormFactor.GooglePlayFeatureGraphic is a banner canvas, not a device. " +
@@ -322,6 +323,7 @@ private fun PhoneBezel(
     modifier: Modifier,
     showStatusBar: Boolean,
     clock: String,
+    statusBarContentDark: Boolean,
     edgeToEdge: Boolean,
     content: @Composable () -> Unit,
 ) {
@@ -343,7 +345,11 @@ private fun PhoneBezel(
                 .clip(RoundedCornerShape(32.dp))
         ) {
             Box(Modifier.fillMaxSize().padding(top = if (edgeToEdge) 0.dp else StatusBarHeight)) { content() }
-            if (showStatusBar) StatusBar(clock, Modifier.align(Alignment.TopCenter))
+            if (showStatusBar) StatusBar(
+                clock,
+                Modifier.align(Alignment.TopCenter),
+                contentColor = if (statusBarContentDark) Color.Black else Color.White,
+            )
             CameraNotch(Modifier.align(Alignment.TopCenter))
         }
     }
@@ -456,6 +462,7 @@ private fun TabletBezel(
     modifier: Modifier,
     showStatusBar: Boolean,
     clock: String,
+    statusBarContentDark: Boolean,
     edgeToEdge: Boolean,
     content: @Composable () -> Unit,
 ) {
@@ -470,7 +477,11 @@ private fun TabletBezel(
             .clip(RoundedCornerShape(20.dp))
     ) {
         Box(Modifier.fillMaxSize().padding(top = if (edgeToEdge) 0.dp else StatusBarHeight)) { content() }
-        if (showStatusBar) StatusBar(clock, Modifier.align(Alignment.TopCenter))
+        if (showStatusBar) StatusBar(
+            clock,
+            Modifier.align(Alignment.TopCenter),
+            contentColor = if (statusBarContentDark) Color.Black else Color.White,
+        )
     }
 }
 
@@ -479,6 +490,7 @@ private fun AppleBezel(
     modifier: Modifier,
     showStatusBar: Boolean,
     clock: String,
+    statusBarContentDark: Boolean,
     edgeToEdge: Boolean,
     content: @Composable () -> Unit,
 ) {
@@ -495,7 +507,11 @@ private fun AppleBezel(
                 .clip(RoundedCornerShape(50.dp))
         ) {
             Box(Modifier.fillMaxSize().padding(top = if (edgeToEdge) 0.dp else StatusBarHeight)) { content() }
-            if (showStatusBar) StatusBar(clock, Modifier.align(Alignment.TopCenter))
+            if (showStatusBar) StatusBar(
+                clock,
+                Modifier.align(Alignment.TopCenter),
+                contentColor = if (statusBarContentDark) Color.Black else Color.White,
+            )
             DynamicIsland(Modifier.align(Alignment.TopCenter))
         }
     }

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotScope.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotScope.kt
@@ -47,6 +47,7 @@ class ScreenshotScope internal constructor(
                 modifier = modifier,
                 showStatusBar = style.showStatusBar,
                 statusBarClock = style.statusBarClock,
+                statusBarContentDark = style.statusBarContentDark,
                 rotationX = rotationX,
                 rotationY = rotationY,
                 rotationZ = rotationZ,

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotStyle.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotStyle.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.unit.dp
  *   bar's height at the top so a standalone screen (rendered without the app's own window insets)
  *   doesn't have its top content — tabs, a top app bar — drawn under the status bar. Phone and
  *   tablet only; the Wear frame has no status bar strip.
+ * - [statusBarContentDark] — when true, the status bar clock and icons use a dark color instead
+ *   of the default white so they stay visible on light mockup backgrounds.
  *
  * Defaults preserve the look of every form factor in the library before this API existed.
  */
@@ -49,6 +51,7 @@ data class ScreenshotStyle(
     val descriptionFontFamily: FontFamily = FontFamily.Default,
     val showStatusBar: Boolean = true,
     val statusBarClock: String = "12:00",
+    val statusBarContentDark: Boolean = false,
     val edgeToEdge: Boolean = true,
     val mockupFrame: (@Composable (content: @Composable () -> Unit) -> Unit)? = null,
     val screenGlass: GlassEffect? = null,

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/AppleFrame.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/AppleFrame.kt
@@ -43,7 +43,7 @@ fun AppleFrame(
         verticalPadding = 28.dp,
         titleFontSize = 26.sp,
         descriptionFontSize = 14.sp,
-        mockup = { externalModifier -> IPhoneMockup(externalModifier, style.showStatusBar, style.statusBarClock, content) }
+        mockup = { externalModifier -> IPhoneMockup(externalModifier, style.showStatusBar, style.statusBarClock, style.statusBarContentDark, content) }
     )
 }
 
@@ -52,6 +52,7 @@ private fun ColumnScope.IPhoneMockup(
     externalModifier: Modifier,
     showStatusBar: Boolean,
     clock: String,
+    statusBarContentDark: Boolean,
     content: @Composable () -> Unit,
 ) {
     Box(
@@ -71,7 +72,11 @@ private fun ColumnScope.IPhoneMockup(
                 .clip(RoundedCornerShape(50.dp))
         ) {
             Box(modifier = Modifier.fillMaxSize()) { content() }
-            if (showStatusBar) StatusBar(clock = clock, modifier = Modifier.align(Alignment.TopCenter))
+            if (showStatusBar) StatusBar(
+                clock = clock,
+                modifier = Modifier.align(Alignment.TopCenter),
+                contentColor = if (statusBarContentDark) Color.Black else Color.White,
+            )
             DynamicIsland(modifier = Modifier.align(Alignment.TopCenter))
         }
     }

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/PhoneFrame.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/PhoneFrame.kt
@@ -46,7 +46,7 @@ fun PhoneFrame(
         style = style,
         horizontalPadding = 28.dp,
         verticalPadding = 48.dp,
-        mockup = { externalModifier -> PhoneMockup(externalModifier, style.showStatusBar, style.statusBarClock, style.edgeToEdge, content) }
+        mockup = { externalModifier -> PhoneMockup(externalModifier, style.showStatusBar, style.statusBarClock, style.statusBarContentDark, style.edgeToEdge, content) }
     )
 }
 
@@ -55,6 +55,7 @@ private fun ColumnScope.PhoneMockup(
     externalModifier: Modifier,
     showStatusBar: Boolean,
     clock: String,
+    statusBarContentDark: Boolean,
     edgeToEdge: Boolean,
     content: @Composable () -> Unit,
 ) {
@@ -98,7 +99,11 @@ private fun ColumnScope.PhoneMockup(
                     .fillMaxSize()
                     .padding(top = if (edgeToEdge) 0.dp else StatusBarHeight)
             ) { content() }
-            if (showStatusBar) StatusBar(clock = clock, modifier = Modifier.align(Alignment.TopCenter))
+            if (showStatusBar) StatusBar(
+                clock = clock,
+                modifier = Modifier.align(Alignment.TopCenter),
+                contentColor = if (statusBarContentDark) Color.Black else Color.White,
+            )
             CameraNotch(modifier = Modifier.align(Alignment.TopCenter))
         }
     }

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/StatusBar.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/StatusBar.kt
@@ -30,7 +30,11 @@ import androidx.compose.ui.unit.sp
 internal val StatusBarHeight: Dp = 38.dp
 
 @Composable
-internal fun StatusBar(clock: String, modifier: Modifier = Modifier) {
+internal fun StatusBar(
+    clock: String,
+    modifier: Modifier = Modifier,
+    contentColor: Color = Color.White,
+) {
     Row(
         modifier = modifier
             .fillMaxWidth()
@@ -39,25 +43,25 @@ internal fun StatusBar(clock: String, modifier: Modifier = Modifier) {
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {
-        Text(text = clock, color = Color.White, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
+        Text(text = clock, color = contentColor, fontSize = 14.sp, fontWeight = FontWeight.SemiBold)
         Row(
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            Icon(Icons.Filled.SignalCellular4Bar, null, tint = Color.White, modifier = Modifier.size(14.dp))
-            Icon(Icons.Filled.Wifi, null, tint = Color.White, modifier = Modifier.size(14.dp))
-            BatteryIcon()
+            Icon(Icons.Filled.SignalCellular4Bar, null, tint = contentColor, modifier = Modifier.size(14.dp))
+            Icon(Icons.Filled.Wifi, null, tint = contentColor, modifier = Modifier.size(14.dp))
+            BatteryIcon(contentColor)
         }
     }
 }
 
 @Composable
-private fun BatteryIcon() {
+private fun BatteryIcon(contentColor: Color) {
     Row(verticalAlignment = Alignment.CenterVertically) {
         Box(
             modifier = Modifier
                 .size(width = 22.dp, height = 11.dp)
-                .border(1.dp, Color.White, RoundedCornerShape(3.dp))
+                .border(1.dp, contentColor, RoundedCornerShape(3.dp))
                 .padding(1.5.dp),
             contentAlignment = Alignment.CenterStart
         ) {
@@ -65,7 +69,7 @@ private fun BatteryIcon() {
                 modifier = Modifier
                     .fillMaxWidth(0.78f)
                     .fillMaxHeight()
-                    .background(Color.White, RoundedCornerShape(1.dp))
+                    .background(contentColor, RoundedCornerShape(1.dp))
             )
         }
         Box(
@@ -73,7 +77,7 @@ private fun BatteryIcon() {
                 .padding(start = 1.dp)
                 .width(1.5.dp)
                 .height(5.dp)
-                .background(Color.White, RoundedCornerShape(topEnd = 1.dp, bottomEnd = 1.dp))
+                .background(contentColor, RoundedCornerShape(topEnd = 1.dp, bottomEnd = 1.dp))
         )
     }
 }

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/TabletFrame.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/TabletFrame.kt
@@ -42,7 +42,7 @@ fun TabletFrame(
         verticalPadding = 56.dp,
         titleFontSize = 36.sp,
         descriptionFontSize = 18.sp,
-        mockup = { externalModifier -> TabletMockup(externalModifier, style.showStatusBar, style.statusBarClock, style.edgeToEdge, aspectRatio, content) }
+        mockup = { externalModifier -> TabletMockup(externalModifier, style.showStatusBar, style.statusBarClock, style.statusBarContentDark, style.edgeToEdge, aspectRatio, content) }
     )
 }
 
@@ -51,6 +51,7 @@ private fun ColumnScope.TabletMockup(
     externalModifier: Modifier,
     showStatusBar: Boolean,
     clock: String,
+    statusBarContentDark: Boolean,
     edgeToEdge: Boolean,
     aspectRatio: Float,
     content: @Composable () -> Unit,
@@ -73,6 +74,10 @@ private fun ColumnScope.TabletMockup(
                 .fillMaxSize()
                 .padding(top = if (edgeToEdge) 0.dp else StatusBarHeight)
         ) { content() }
-        if (showStatusBar) StatusBar(clock = clock, modifier = Modifier.align(Alignment.TopCenter))
+        if (showStatusBar) StatusBar(
+            clock = clock,
+            modifier = Modifier.align(Alignment.TopCenter),
+            contentColor = if (statusBarContentDark) Color.Black else Color.White,
+        )
     }
 }


### PR DESCRIPTION
The status bar clock and icons were hardcoded to white, making them invisible on light mockup backgrounds. Added a new `statusBarContentDark` boolean (default `false`) that switches the status bar content color to dark when enabled.

The option is threaded through all affected rendering paths:
- ScreenshotStyle (new field)
- DeviceMockup (new parameter, all three bezel types)
- ScreenshotScope.Mockup (forwarded to DeviceMockup)
- PhoneFrame, TabletFrame, AppleFrame (frame-level mockup functions)
- StatusBar / BatteryIcon (contentColor parameter replacing hardcoded Color.White)

Defaults to false, preserving the existing white appearance.