### PR TITLE
Add a 6.5" iPhone form factor

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,20 @@ storeScreenshots {
 | `Tablet7` | 1200 x 1920 | `sevenInchScreenshots` |
 | `Tablet10` | 1600 x 2560 | `tenInchScreenshots` |
 | `AppleIPhone67` | 1290 x 2796 | `iphone67` |
+| `AppleIPhone65` | 1284 x 2778 | `iphone65` |
 | `GooglePlayFeatureGraphic` | 1024 x 500 | `featureGraphic` |
+
+Both iPhone sizes are accepted by App Store Connect. It offers the **6.5" slot by default**
+and scales that image into the other iPhone sizes, so `AppleIPhone65` is usually the one to
+fill first. `AppleIPhone67` matches the 6.7" slot.
+
+The two draw different hardware, because they depict different phones: 6.7" gets a Dynamic
+Island, 6.5" gets a notch (those devices shipped before the Island existed). Override it on
+`AppleFrame` with `notch = AppleNotchStyle.DynamicIsland | .Notch` if you are composing the
+frame yourself.
+
+Apple form factors write to `{locale}/{subdir}/`, without the `images/` level Play uses — set
+`destDir` to `fastlane/screenshots` for them and `fastlane/metadata/android` for Play.
 
 ### Feature graphic
 
@@ -323,7 +336,8 @@ fun HomePreview() = ScreenshotPreview(
 | `@Tablet7ScreenshotPreview` | 600 x 960 dp |
 | `@Tablet10ScreenshotPreview` | 800 x 1280 dp |
 | `@AppleIPhone67ScreenshotPreview` | 430 x 932 dp |
-| `@AllScreenshotPreviews` | All five at once |
+| `@AppleIPhone65ScreenshotPreview` | 428 x 926 dp |
+| `@AllScreenshotPreviews` | All six at once |
 
 Previews go in `src/debug/` (Studio only renders debug variant). Tests go in `src/screenshots/`. Shared composables go in `src/main/`.
 

--- a/example/src/main/res/values-pt-rBR/strings.xml
+++ b/example/src/main/res/values-pt-rBR/strings.xml
@@ -8,6 +8,7 @@
     <string name="screenshot_tablet10_desc">Layout de 10 polegadas usa a mesma UI Compose</string>
     <string name="screenshot_apple_title">Publique em todas as lojas</string>
     <string name="screenshot_apple_desc">Tamanho 6.7\" do App Store Connect, pronto para enviar</string>
+    <string name="screenshot_apple65_desc">Tamanho 6.5\" do App Store Connect, pronto para enviar</string>
     <string name="screenshot_feature_title">Imagens de destaque incríveis</string>
     <string name="screenshot_feature_desc">Feito inteiramente com Jetpack Compose</string>
     <string name="screenshot_styled_title">Do seu jeito</string>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -8,6 +8,7 @@
     <string name="screenshot_tablet10_desc">10-inch layout uses identical Compose UI</string>
     <string name="screenshot_apple_title">Ship cross-store</string>
     <string name="screenshot_apple_desc">App Store Connect 6.7\" size, ready to upload</string>
+    <string name="screenshot_apple65_desc">App Store Connect 6.5\" size, ready to upload</string>
     <string name="screenshot_feature_title">Beautiful feature graphics</string>
     <string name="screenshot_feature_desc">Built entirely with Jetpack Compose</string>
     <string name="screenshot_styled_title">Designed your way</string>

--- a/example/src/screenshots/kotlin/dev/lucianosantos/storescreenshots/example/AppleIPhone65ExampleTest.kt
+++ b/example/src/screenshots/kotlin/dev/lucianosantos/storescreenshots/example/AppleIPhone65ExampleTest.kt
@@ -1,0 +1,16 @@
+package dev.lucianosantos.storescreenshots.example
+
+import dev.lucianosantos.storescreenshots.FormFactor
+import dev.lucianosantos.storescreenshots.StoreScreenshotsTest
+import org.junit.Test
+
+/** The 6.5" slot App Store Connect selects by default. */
+class AppleIPhone65ExampleTest : StoreScreenshotsTest(FormFactor.AppleIPhone65) {
+
+    @Test
+    fun counter() = screenshot(
+        locales = listOf("en-US", "pt-BR"),
+        titleRes = R.string.screenshot_apple_title,
+        descriptionRes = R.string.screenshot_apple65_desc,
+    ) { CounterScreen(count = 42) }
+}

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/DeviceMockup.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/DeviceMockup.kt
@@ -157,6 +157,10 @@ fun DeviceMockup(
             val (w, h) = orientSize(430.dp, 932.dp, orientation)
             ScaledMockup(w, h, rotated) { AppleBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
         }
+        FormFactor.AppleIPhone65 -> {
+            val (w, h) = orientSize(428.dp, 926.dp, orientation)
+            ScaledMockup(w, h, rotated) { AppleBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
+        }
         FormFactor.GooglePlayFeatureGraphic -> error(
             "FormFactor.GooglePlayFeatureGraphic is a banner canvas, not a device. " +
                 "Compose real devices with DeviceMockup(formFactor = FormFactor.Phone / Tablet10 / …) " +

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/FormFactor.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/FormFactor.kt
@@ -66,6 +66,25 @@ enum class FormFactor(
     ),
 
     /**
+     * Apple App Store iPhone 6.5" screenshot. Portrait 1284x2778 (iPhone 12/13/14 Plus and Pro Max).
+     *
+     * The size App Store Connect selects by default, so it is usually the slot to fill first —
+     * Apple scales it into the others. The 6.5" slot also accepts 1242x2688 (414dp x 896dp);
+     * 428dp x 926dp is used here because it is the taller, current-generation ratio and Apple
+     * takes either.
+     *
+     * These devices have a notch rather than a Dynamic Island, which is why [AppleFrame] takes
+     * the cutout as a parameter.
+     */
+    AppleIPhone65(
+        widthPx = 1284,
+        heightPx = 2778,
+        qualifiers = "w428dp-h926dp-xxhdpi",
+        subdir = "iphone65",
+        useImagesSubdir = false,
+    ),
+
+    /**
      * Google Play feature graphic. Landscape 1024x500 promotional banner shown at the top of
      * the store listing. `512dp x 250dp` at xhdpi (density 2.0) renders exactly 1024x500 px.
      * It is a single image, not a folder of screenshots, so `subdir = "."` places it directly at

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreview.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreview.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Box
 import androidx.compose.ui.unit.dp
 import dev.lucianosantos.storescreenshots.frames.AppleFrame
+import dev.lucianosantos.storescreenshots.frames.AppleNotchStyle
 import dev.lucianosantos.storescreenshots.frames.FramedLayout
 import dev.lucianosantos.storescreenshots.frames.PhoneFrame
 import dev.lucianosantos.storescreenshots.frames.TabletFrame
@@ -70,7 +71,18 @@ fun ScreenshotPreview(
             FormFactor.Wear -> WearFrame(backgroundColor, content)
             FormFactor.Tablet7,
             FormFactor.Tablet10 -> TabletFrame(title, description, backgroundColor, contentColor, style, content = content)
-            FormFactor.AppleIPhone67 -> AppleFrame(title, description, backgroundColor, contentColor, style, content)
+            FormFactor.AppleIPhone67 -> AppleFrame(
+                title, description, backgroundColor, contentColor, style,
+                aspectRatio = 1290f / 2796f,
+                notch = AppleNotchStyle.DynamicIsland,
+                content = content,
+            )
+            FormFactor.AppleIPhone65 -> AppleFrame(
+                title, description, backgroundColor, contentColor, style,
+                aspectRatio = 1284f / 2778f,
+                notch = AppleNotchStyle.Notch,
+                content = content,
+            )
             // Guarded against above; a feature graphic is previewed via its own banner composable.
             FormFactor.GooglePlayFeatureGraphic -> error("unreachable")
         }

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreviews.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreviews.kt
@@ -34,6 +34,9 @@ annotation class Tablet10ScreenshotPreview
 @Preview(name = "iPhone 6.7\" (1290×2796)", widthDp = 430, heightDp = 932)
 annotation class AppleIPhone67ScreenshotPreview
 
+@Preview(name = "iPhone 6.5\" (1284×2778)", widthDp = 428, heightDp = 926)
+annotation class AppleIPhone65ScreenshotPreview
+
 // Rendered at 1.5× the 1024×500 output so the short banner isn't dwarfed by the phone/tablet
 // previews beside it — see the note above. The exported PNG is unaffected (that comes from the test).
 @Preview(name = "Feature Graphic (1024×500)", widthDp = 1536, heightDp = 750)
@@ -48,5 +51,6 @@ annotation class GooglePlayFeatureGraphicScreenshotPreview
 @Tablet7ScreenshotPreview
 @Tablet10ScreenshotPreview
 @AppleIPhone67ScreenshotPreview
+@AppleIPhone65ScreenshotPreview
 @GooglePlayFeatureGraphicScreenshotPreview
 annotation class AllScreenshotPreviews

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import kotlin.math.roundToInt
 import dev.lucianosantos.storescreenshots.frames.AppleFrame
+import dev.lucianosantos.storescreenshots.frames.AppleNotchStyle
 import dev.lucianosantos.storescreenshots.frames.FramedLayout
 import dev.lucianosantos.storescreenshots.frames.PhoneFrame
 import dev.lucianosantos.storescreenshots.frames.TabletFrame
@@ -307,7 +308,18 @@ class ScreenshotRule(
                 FormFactor.Wear -> WearFrame(backgroundColor, content)
                 FormFactor.Tablet7,
                 FormFactor.Tablet10 -> TabletFrame(title, description, backgroundColor, contentColor, style, content = content)
-                FormFactor.AppleIPhone67 -> AppleFrame(title, description, backgroundColor, contentColor, style, content)
+                FormFactor.AppleIPhone67 -> AppleFrame(
+                    title, description, backgroundColor, contentColor, style,
+                    aspectRatio = 1290f / 2796f,
+                    notch = AppleNotchStyle.DynamicIsland,
+                    content = content,
+                )
+                FormFactor.AppleIPhone65 -> AppleFrame(
+                    title, description, backgroundColor, contentColor, style,
+                    aspectRatio = 1284f / 2778f,
+                    notch = AppleNotchStyle.Notch,
+                    content = content,
+                )
                 // Guarded against in screenshot(); a feature graphic is composed via customScreenshot.
                 FormFactor.GooglePlayFeatureGraphic -> error("unreachable")
             }

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/AppleFrame.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/frames/AppleFrame.kt
@@ -20,9 +20,21 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dev.lucianosantos.storescreenshots.ScreenshotStyle
 
+/** The screen cutout an iPhone frame draws. */
+enum class AppleNotchStyle {
+    /** Pill-shaped Dynamic Island — iPhone 14 Pro and later. */
+    DynamicIsland,
+
+    /** Wide top notch — iPhone X through 14 Plus, which is what the 6.5" slot depicts. */
+    Notch,
+}
+
 /**
- * iPhone frame with Dynamic Island for Apple App Store screenshots.
- * Targets 6.7" iPhone (1290x2796) — the size App Store Connect requires for new submissions.
+ * iPhone frame for Apple App Store screenshots.
+ *
+ * Defaults to the 6.7" body (1290x2796, Dynamic Island). Pass [aspectRatio] and [notch] to draw a
+ * different iPhone — the 6.5" slot (1284x2778) shows devices that shipped with a notch, so drawing
+ * a Dynamic Island there would depict a phone that never existed at that size.
  */
 @Composable
 fun AppleFrame(
@@ -31,6 +43,8 @@ fun AppleFrame(
     backgroundColor: Color,
     contentColor: Color = Color.White,
     style: ScreenshotStyle = ScreenshotStyle(),
+    aspectRatio: Float = 1290f / 2796f,
+    notch: AppleNotchStyle = AppleNotchStyle.DynamicIsland,
     content: @Composable () -> Unit,
 ) {
     FramedLayout(
@@ -43,7 +57,17 @@ fun AppleFrame(
         verticalPadding = 28.dp,
         titleFontSize = 26.sp,
         descriptionFontSize = 14.sp,
-        mockup = { externalModifier -> IPhoneMockup(externalModifier, style.showStatusBar, style.statusBarClock, style.statusBarContentDark, content) }
+        mockup = { externalModifier ->
+            IPhoneMockup(
+                externalModifier,
+                style.showStatusBar,
+                style.statusBarClock,
+                style.statusBarContentDark,
+                aspectRatio,
+                notch,
+                content
+            )
+        }
     )
 }
 
@@ -53,12 +77,14 @@ private fun ColumnScope.IPhoneMockup(
     showStatusBar: Boolean,
     clock: String,
     statusBarContentDark: Boolean,
+    aspectRatio: Float,
+    notch: AppleNotchStyle,
     content: @Composable () -> Unit,
 ) {
     Box(
         modifier = externalModifier
             .fillMaxHeight()
-            .aspectRatio(1290f / 2796f)
+            .aspectRatio(aspectRatio)
     ) {
         Box(
             modifier = Modifier
@@ -77,7 +103,10 @@ private fun ColumnScope.IPhoneMockup(
                 modifier = Modifier.align(Alignment.TopCenter),
                 contentColor = if (statusBarContentDark) Color.Black else Color.White,
             )
-            DynamicIsland(modifier = Modifier.align(Alignment.TopCenter))
+            when (notch) {
+                AppleNotchStyle.DynamicIsland -> DynamicIsland(Modifier.align(Alignment.TopCenter))
+                AppleNotchStyle.Notch -> Notch(Modifier.align(Alignment.TopCenter))
+            }
         }
     }
 }
@@ -91,5 +120,19 @@ private fun DynamicIsland(modifier: Modifier = Modifier) {
             .clip(RoundedCornerShape(50))
             .background(Color.Black)
             .border(0.5.dp, Color(0xFF222222), RoundedCornerShape(50))
+    )
+}
+
+/**
+ * The pre-14-Pro notch: flush with the top edge, so only its bottom corners are rounded.
+ * Wider and shorter than the Dynamic Island, and not inset from the top.
+ */
+@Composable
+private fun Notch(modifier: Modifier = Modifier) {
+    Box(
+        modifier = modifier
+            .size(width = 156.dp, height = 30.dp)
+            .clip(RoundedCornerShape(bottomStart = 20.dp, bottomEnd = 20.dp))
+            .background(Color.Black)
     )
 }


### PR DESCRIPTION
## Why

App Store Connect selects the **6.5" slot by default** and scales it into the other iPhone sizes, so it is the one most listings need to fill first. The only Apple form factor here was 6.7" (1290x2796), which that slot rejects.

## What

`FormFactor.AppleIPhone65` renders **1284x2778** (`w428dp-h926dp-xxhdpi`). The slot also accepts 1242x2688; the taller ratio is used because it matches current devices and Apple takes either.

Those devices shipped with a **notch, not a Dynamic Island**, so `AppleFrame` now takes the body ratio and cutout as parameters instead of hardcoding the 6.7" ones — drawing an Island at 6.5" would depict a phone that never existed. `AppleNotchStyle` is the new knob; the defaults keep `AppleFrame` behaving exactly as before for existing callers.

Also extends the three exhaustive `when` blocks over `FormFactor` (`ScreenshotRule.renderFrame`, `DeviceMockup`, `ScreenshotPreview`) and adds `@AppleIPhone65ScreenshotPreview`.

## Verified

`./gradlew :example:storeScreenshots` — output read back from the PNG headers:

| File | Size |
|---|---|
| `en-US/iphone65/counter.png` | **1284x2778** |
| `en-US/iphone67/counter.png` | 1290x2796 (unchanged) |

The example gets an `AppleIPhone65ExampleTest` and its own caption string, so the sample no longer says 6.7" under a 6.5" image.

## Note

Rebased onto #1, which landed while this was in progress. The two overlap in `AppleFrame`/`DeviceMockup` — `statusBarContentDark` and the new `aspectRatio`/`notch` parameters are combined rather than one replacing the other.