### PR TITLE
Add AppleIPad13 form factor (2048×2732)

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ storeScreenshots {
 | `Tablet10` | 1600 x 2560 | `tenInchScreenshots` |
 | `AppleIPhone67` | 1290 x 2796 | `iphone67` |
 | `AppleIPhone65` | 1284 x 2778 | `iphone65` |
+| `AppleIPad13` | 2048 x 2732 | `ipad13` |
 | `GooglePlayFeatureGraphic` | 1024 x 500 | `featureGraphic` |
 
 Both iPhone sizes are accepted by App Store Connect. It offers the **6.5" slot by default**
@@ -155,6 +156,10 @@ The two draw different hardware, because they depict different phones: 6.7" gets
 Island, 6.5" gets a notch (those devices shipped before the Island existed). Override it on
 `AppleFrame` with `notch = AppleNotchStyle.DynamicIsland | .Notch` if you are composing the
 frame yourself.
+
+`AppleIPad13` fills the **13" iPad** slot, which App Store Connect requires for any app that
+runs on iPad — even an iPhone-first app still lists there. It renders 2048 x 2732 (the slot also
+accepts 2064 x 2752 and either landscape) with the neutral tablet bezel, no notch.
 
 Apple form factors write to `{locale}/{subdir}/`, without the `images/` level Play uses — set
 `destDir` to `fastlane/screenshots` for them and `fastlane/metadata/android` for Play.
@@ -337,7 +342,8 @@ fun HomePreview() = ScreenshotPreview(
 | `@Tablet10ScreenshotPreview` | 800 x 1280 dp |
 | `@AppleIPhone67ScreenshotPreview` | 430 x 932 dp |
 | `@AppleIPhone65ScreenshotPreview` | 428 x 926 dp |
-| `@AllScreenshotPreviews` | All six at once |
+| `@AppleIPad13ScreenshotPreview` | 1024 x 1366 dp |
+| `@AllScreenshotPreviews` | All seven at once |
 
 Previews go in `src/debug/` (Studio only renders debug variant). Tests go in `src/screenshots/`. Shared composables go in `src/main/`.
 

--- a/example/src/screenshots/kotlin/dev/lucianosantos/storescreenshots/example/AppleIPad13ExampleTest.kt
+++ b/example/src/screenshots/kotlin/dev/lucianosantos/storescreenshots/example/AppleIPad13ExampleTest.kt
@@ -1,0 +1,16 @@
+package dev.lucianosantos.storescreenshots.example
+
+import dev.lucianosantos.storescreenshots.FormFactor
+import dev.lucianosantos.storescreenshots.StoreScreenshotsTest
+import org.junit.Test
+
+/** The 13" iPad slot App Store Connect requires for any app that runs on iPad. */
+class AppleIPad13ExampleTest : StoreScreenshotsTest(FormFactor.AppleIPad13) {
+
+    @Test
+    fun counter() = screenshot(
+        locales = listOf("en-US", "pt-BR"),
+        titleRes = R.string.screenshot_apple_title,
+        descriptionRes = R.string.screenshot_apple_desc,
+    ) { CounterScreen(count = 42) }
+}

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/DeviceMockup.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/DeviceMockup.kt
@@ -161,6 +161,12 @@ fun DeviceMockup(
             val (w, h) = orientSize(428.dp, 926.dp, orientation)
             ScaledMockup(w, h, rotated) { AppleBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
         }
+        FormFactor.AppleIPad13 -> {
+            // 4:3 to match the w1024dp-h1366dp qualifier (12.9"/13" iPad). Uses the neutral tablet
+            // bezel — a uniform rounded frame, no notch — which reads as an iPad.
+            val (w, h) = orientSize(1024.dp, 1366.dp, orientation)
+            ScaledMockup(w, h, rotated) { TabletBezel(Modifier.fillMaxSize(), showStatusBar, statusBarClock, statusBarContentDark, edgeToEdge) { ProvideDeviceConfiguration(w, h, content) } }
+        }
         FormFactor.GooglePlayFeatureGraphic -> error(
             "FormFactor.GooglePlayFeatureGraphic is a banner canvas, not a device. " +
                 "Compose real devices with DeviceMockup(formFactor = FormFactor.Phone / Tablet10 / …) " +

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/FormFactor.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/FormFactor.kt
@@ -85,6 +85,25 @@ enum class FormFactor(
     ),
 
     /**
+     * Apple App Store 13" iPad screenshot. Portrait 2048x2732 (12.9"/13" iPad Pro & iPad Air).
+     *
+     * App Store Connect requires a 13" iPad screenshot to submit any app that runs on iPad — even an
+     * iPhone-first design still lists on iPad, so the slot is mandatory. 2048x2732 is the long-standing
+     * size the slot accepts (1024dp x 1366dp at @2x / xhdpi); it also takes 2064x2752 and either
+     * landscape orientation. The 4:3 portrait 2048x2732 used here is what every iPad build has shipped.
+     *
+     * Drawn with the same neutral tablet bezel as the Android tablets in [DeviceMockup] — a uniform
+     * rounded frame with no notch, which reads correctly as an iPad.
+     */
+    AppleIPad13(
+        widthPx = 2048,
+        heightPx = 2732,
+        qualifiers = "w1024dp-h1366dp-xhdpi",
+        subdir = "ipad13",
+        useImagesSubdir = false,
+    ),
+
+    /**
      * Google Play feature graphic. Landscape 1024x500 promotional banner shown at the top of
      * the store listing. `512dp x 250dp` at xhdpi (density 2.0) renders exactly 1024x500 px.
      * It is a single image, not a folder of screenshots, so `subdir = "."` places it directly at

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreview.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreview.kt
@@ -70,7 +70,9 @@ fun ScreenshotPreview(
             FormFactor.Phone -> PhoneFrame(title, description, backgroundColor, contentColor, style, content)
             FormFactor.Wear -> WearFrame(backgroundColor, content)
             FormFactor.Tablet7,
-            FormFactor.Tablet10 -> TabletFrame(title, description, backgroundColor, contentColor, style, content = content)
+            FormFactor.Tablet10,
+            // The 13" iPad uses the same neutral tablet frame — no notch, uniform bezel.
+            FormFactor.AppleIPad13 -> TabletFrame(title, description, backgroundColor, contentColor, style, content = content)
             FormFactor.AppleIPhone67 -> AppleFrame(
                 title, description, backgroundColor, contentColor, style,
                 aspectRatio = 1290f / 2796f,

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreviews.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotPreviews.kt
@@ -37,6 +37,9 @@ annotation class AppleIPhone67ScreenshotPreview
 @Preview(name = "iPhone 6.5\" (1284×2778)", widthDp = 428, heightDp = 926)
 annotation class AppleIPhone65ScreenshotPreview
 
+@Preview(name = "iPad 13\" (2048×2732)", widthDp = 1024, heightDp = 1366)
+annotation class AppleIPad13ScreenshotPreview
+
 // Rendered at 1.5× the 1024×500 output so the short banner isn't dwarfed by the phone/tablet
 // previews beside it — see the note above. The exported PNG is unaffected (that comes from the test).
 @Preview(name = "Feature Graphic (1024×500)", widthDp = 1536, heightDp = 750)
@@ -52,5 +55,6 @@ annotation class GooglePlayFeatureGraphicScreenshotPreview
 @Tablet10ScreenshotPreview
 @AppleIPhone67ScreenshotPreview
 @AppleIPhone65ScreenshotPreview
+@AppleIPad13ScreenshotPreview
 @GooglePlayFeatureGraphicScreenshotPreview
 annotation class AllScreenshotPreviews

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
@@ -307,7 +307,9 @@ class ScreenshotRule(
                 FormFactor.Phone -> PhoneFrame(title, description, backgroundColor, contentColor, style, content)
                 FormFactor.Wear -> WearFrame(backgroundColor, content)
                 FormFactor.Tablet7,
-                FormFactor.Tablet10 -> TabletFrame(title, description, backgroundColor, contentColor, style, content = content)
+                FormFactor.Tablet10,
+                // The 13" iPad uses the same neutral tablet frame — no notch, uniform bezel.
+                FormFactor.AppleIPad13 -> TabletFrame(title, description, backgroundColor, contentColor, style, content = content)
                 FormFactor.AppleIPhone67 -> AppleFrame(
                     title, description, backgroundColor, contentColor, style,
                     aspectRatio = 1290f / 2796f,


### PR DESCRIPTION
## What

Adds an `AppleIPad13` form factor rendering **2048×2732** — the 13" iPad App Store screenshot slot.

## Why

App Store Connect **requires** a 13" iPad screenshot to submit any app that runs on iPad, even a phone-first one. There was no form factor for it, so an iPad-capable app couldn't complete an App Store submission from this library (you hit *"You must upload a screenshot for 13-inch iPad displays"*).

## How

- `FormFactor.AppleIPad13` — 2048×2732 (1024dp×1366dp @ xhdpi), `subdir = "ipad13"`, no `images/` level (like the other Apple form factors). 2048×2732 is the long-standing size the slot accepts.
- `DeviceMockup` reuses the neutral **tablet bezel** — a uniform rounded frame, no notch — which reads correctly as an iPad.
- The framed `screenshot()` path routes it through `TabletFrame` alongside the Android tablets (both exhaustive `when`s updated).
- `@AppleIPad13ScreenshotPreview` (1024×1366 dp) added, plus `@AllScreenshotPreviews` and the README form-factor / preview tables.

## Validation

New `AppleIPad13ExampleTest` in the example module renders at **exactly 2048×2732** — verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)