### PR TITLE
Add ui-test-manifest to the consumer so createComposeRule can launch

### DIFF
--- a/plugin/src/main/kotlin/dev/lucianosantos/storescreenshots/gradle/StoreScreenshotsPlugin.kt
+++ b/plugin/src/main/kotlin/dev/lucianosantos/storescreenshots/gradle/StoreScreenshotsPlugin.kt
@@ -17,7 +17,8 @@ import java.util.Properties
  * 1. Applies the Roborazzi Gradle plugin (so `captureRoboImage` works at test time).
  * 2. Adds `src/screenshots/{kotlin,res}` to the Android `test` source set so screenshot code
  *    lives separately from regular unit tests without needing a custom build variant.
- * 3. Wires the store-screenshots library in as a `testImplementation` dependency.
+ * 3. Wires the store-screenshots library in as a `testImplementation` dependency, plus
+ *    `ui-test-manifest` on debug so `createComposeRule()` has an activity to launch.
  * 4. Enables Android resource & return-default-values in unit tests (Robolectric needs both).
  * 5. Sets `storeScreenshots.outputRoot` to the root project dir on all `Test` tasks,
  *    so screenshots land at `<repoRoot>/fastlane/metadata/...` regardless of which module
@@ -41,6 +42,7 @@ class StoreScreenshotsPlugin : Plugin<Project> {
         // Also add to debug so Android Studio can render @Preview functions that
         // reference library classes (ScreenshotPreview, FormFactor, frames, etc.).
         target.dependencies.add("debugImplementation", libraryNotation())
+        target.dependencies.add("debugImplementation", "androidx.compose.ui:ui-test-manifest")
 
         // If the consuming project lives in the same build as a `:library` project that
         // matches our group/name (i.e. the example module inside this very repo), wire it


### PR DESCRIPTION
Fixes #8.

`createComposeRule()` launches `androidx.activity.ComponentActivity`, which is only in the merged manifest when `ui-test-manifest` is on the variant under test. The library depends on it as `debugImplementation`, and only the release variant is published — so the dependency never reached consumers and every project failed on its first `storeScreenshots` run with `Unable to resolve activity for Intent … ComponentActivity`. The example module was immune because it declares the dependency itself.

The plugin already adds `debugImplementation(libraryNotation())` for `@Preview` support; this adds one line next to it. No version is given: the library api-exposes the Compose BOM, which supplies the constraint.

Verified on a Compose Multiplatform app that previously failed with that exception — after this it runs with the plugin id as the only declaration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)