### PR TITLE
Write opaque PNGs — Play rejects alpha on wear screenshots

### DIFF
--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
@@ -3,6 +3,7 @@ package dev.lucianosantos.storescreenshots
 import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
+import android.graphics.Canvas
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.test.junit4.ComposeContentTestRule
@@ -132,6 +133,7 @@ class ScreenshotRule(
                             filePath = outputFile.absolutePath,
                             roborazziOptions = RoborazziOptions(),
                         )
+                        flattenToOpaque(outputFile)
                     }
                 },
                 junitDescription,
@@ -171,10 +173,12 @@ class ScreenshotRule(
                         composeRule.waitForIdle()
                         beforeCapture(composeRule)
                         composeRule.waitForIdle()
+                        val outputFile = outputPath(locale, fileName ?: testMethodName, subdir)
                         composeRule.onRoot().captureRoboImage(
-                            filePath = outputPath(locale, fileName ?: testMethodName, subdir).absolutePath,
+                            filePath = outputFile.absolutePath,
                             roborazziOptions = RoborazziOptions(),
                         )
+                        flattenToOpaque(outputFile)
                     }
                 },
                 junitDescription,
@@ -279,8 +283,36 @@ class ScreenshotRule(
             val width = minOf(panelWidth, full.width - x)
             val slice = Bitmap.createBitmap(full, x, 0, width, full.height)
             val name = "${base}_${(i + 1).toString().padStart(2, '0')}"
-            outputPath(locale, name, subdir).outputStream().use { slice.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            val target = outputPath(locale, name, subdir)
+            target.outputStream().use { slice.compress(Bitmap.CompressFormat.PNG, 100, it) }
+            flattenToOpaque(target)
         }
+    }
+
+    /**
+     * Rewrites [file] without an alpha channel, if it has one.
+     *
+     * Roborazzi captures ARGB_8888 and encodes RGBA, but both stores ask for 24-bit PNG,
+     * and Google Play enforces it on at least one slot: uploading a wear screenshot with
+     * alpha to `listings/{lang}/wearScreenshots` returns a bare HTTP 500, while the same
+     * image flattened to RGB returns 200 (verified against the Publisher API in August
+     * 2026 — the phone slot still accepts alpha, so this surfaced as a listing upload that
+     * failed for four consecutive releases with no usable error).
+     *
+     * Composited onto black rather than white: store frames are captured over a dark
+     * backdrop, and a white matte would fringe any anti-aliased edge that is translucent.
+     */
+    private fun flattenToOpaque(file: File) {
+        val src = BitmapFactory.decodeFile(file.absolutePath) ?: return
+        if (!src.hasAlpha()) return
+        val flat = Bitmap.createBitmap(src.width, src.height, Bitmap.Config.ARGB_8888)
+        Canvas(flat).apply {
+            drawColor(android.graphics.Color.BLACK)
+            drawBitmap(src, 0f, 0f, null)
+        }
+        // Marks the alpha type opaque, which is what makes the encoder drop the channel.
+        flat.setHasAlpha(false)
+        file.outputStream().use { flat.compress(Bitmap.CompressFormat.PNG, 100, it) }
     }
 
     @Composable

--- a/library/src/test/kotlin/dev/lucianosantos/storescreenshots/OpaqueOutputTest.kt
+++ b/library/src/test/kotlin/dev/lucianosantos/storescreenshots/OpaqueOutputTest.kt
@@ -1,0 +1,75 @@
+package dev.lucianosantos.storescreenshots
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * Every PNG this library writes must be opaque — no alpha channel.
+ *
+ * Not a cosmetic preference. Google Play's images endpoint returns a bare HTTP 500 when a
+ * wear screenshot carries an alpha channel, while the same image flattened to RGB returns
+ * 200 (verified against the Publisher API in August 2026). Because `supply` aborts the
+ * whole listing upload on the first failure, one RGBA wear screenshot silently froze an
+ * entire store listing — phone screenshots, texts and all — across four consecutive
+ * releases, with nothing in the error to point at the cause.
+ *
+ * Roborazzi captures ARGB_8888, so without the flatten in [ScreenshotRule] every output
+ * regresses to RGBA at once. This is the guard.
+ */
+class OpaqueOutputTest : StoreScreenshotsTest(FormFactor.Phone) {
+
+    @Test
+    fun opaqueContentIsWrittenWithoutAnAlphaChannel() {
+        screenshot(fileName = "opaque") {
+            Box(Modifier.fillMaxSize().background(Color(0xFF6A1B9A)))
+        }
+        assertNoAlpha(written("opaque"))
+    }
+
+    /**
+     * A translucent composition is the case that would betray a flatten that only *marks*
+     * the bitmap opaque without compositing it: the channel would be gone but the colours
+     * would be wrong. Asserting the result reads as the blend over black covers both.
+     */
+    @Test
+    fun translucentContentIsCompositedRatherThanJustMarkedOpaque() {
+        screenshot(fileName = "translucent") {
+            Box(Modifier.fillMaxSize().background(Color.White.copy(alpha = 0.5f)))
+        }
+
+        val png = written("translucent")
+        assertNoAlpha(png)
+
+        val image = ImageIO.read(png)
+        // Sampled inside the device mockup, where the translucent content is drawn.
+        val centre = image.getRGB(image.width / 2, image.height / 2)
+        val red = (centre shr 16) and 0xFF
+        assertTrue(
+            "centre pixel red was $red — 50% white over black should land mid-grey; " +
+                "full white would mean the alpha was discarded rather than composited",
+            red in 90..170
+        )
+    }
+
+    private fun written(name: String): File {
+        val root = ScreenshotRule.defaultOutputRoot()
+        return root.walkTopDown().firstOrNull { it.name == "$name.png" }
+            ?: error("no $name.png written under $root")
+    }
+
+    private fun assertNoAlpha(file: File) {
+        val image = ImageIO.read(file) ?: error("could not decode $file")
+        assertFalse(
+            "${file.name} still carries an alpha channel — Play rejects that on wearScreenshots",
+            image.colorModel.hasAlpha()
+        )
+    }
+}


### PR DESCRIPTION
## The bug

Roborazzi captures ARGB_8888 and encodes RGBA. Both stores ask for 24-bit PNG, and Google Play started enforcing it on at least one slot: uploading a wear screenshot with an alpha channel returns a bare **HTTP 500**, while the identical image flattened to RGB returns **200**.

Verified against the Publisher API directly:

| request | result |
|---|---|
| `POST .../listings/ar/phoneScreenshots` (wear PNG, RGBA) | ✅ 200 |
| `POST .../listings/ar/wearScreenshots` (same PNG, RGBA) | ❌ 500 |
| `POST .../listings/en-US/wearScreenshots` (same PNG, RGBA) | ❌ 500 |
| `POST .../listings/en-US/wearScreenshots` (phone-shaped PNG) | ❌ 400 |
| `POST .../listings/en-US/wearScreenshots` (**flattened to RGB**) | ✅ 200 |

The 400 matters: the endpoint validates shape correctly and rejects a wrong-shaped image cleanly, then chokes on the alpha channel of a correctly-shaped one.

## Why it was worth chasing

The consequence for a consumer is out of all proportion to the cause. `fastlane supply` uploads locale by locale and aborts the whole lane on the first failure, so one RGBA wear screenshot froze an entire Play listing — every phone screenshot, every text, in every locale — across **four consecutive releases** of the app that hit this. It read as a flaky Google outage, because the locale it died on moved every run (`ar`, `fi-FI`, `da-DK`, `en-US`, `es-ES`) depending on which locale reached its wear images first.

The images themselves were byte-identical to ones that had uploaded successfully weeks earlier, which is what made it look like anything but a client-side problem.

## The change

`ScreenshotRule.flattenToOpaque()` rewrites each PNG without its alpha channel, called from all three write paths — `screenshot()`, `customScreenshot()` and the split slices. Composited onto **black** rather than white: store frames are captured over a dark backdrop, so a white matte would fringe any anti-aliased translucent edge.

## Tests

`OpaqueOutputTest` covers both halves:

- the written PNG has no alpha channel;
- translucent content was actually **composited**, not merely marked opaque — a flatten that only sets the alpha type would drop the channel while leaving the colours wrong, so it asserts 50% white over black lands mid-grey.

Both fail with the flatten removed. The example module's 53 screenshots now come out RGB with no visual change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)