### PR TITLE
Correct the canvas rationale, and the sizes the docs quote for it

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,33 +157,6 @@ Island, 6.5" gets a notch (those devices shipped before the Island existed). Ove
 `AppleFrame` with `notch = AppleNotchStyle.DynamicIsland | .Notch` if you are composing the
 frame yourself.
 
-### Changing the canvas size
-
-The sizes above are defaults, not requirements. Play accepts any portrait phone screenshot from
-320px to 3840px so long as the long side is no more than twice the short side, and where you sit
-in that range is a design decision. Pass a `ScreenshotCanvas` to make it:
-
-```kotlin
-class HomeShots : StoreScreenshotsTest(
-    FormFactor.Phone,
-    canvas = ScreenshotCanvas.px(1080, 1920),   // or .dp(414, 736)
-)
-```
-
-`Phone` defaults to **1242 x 2484 — exactly 1:2**, the tallest shape Play accepts and so the one
-that leaves the device mockup largest. Play's promotional-eligibility guidance separately asks for
-**9:16** at 1080px or wider, which is a genuine trade rather than a free upgrade: at 9:16 there is
-much less height left beside the title and description, so the mockup shrinks by roughly a quarter
-and the shot reads emptier. Take it deliberately with `ScreenshotCanvas.px(1080, 1920)`.
-
-Only the size is replaced — every other qualifier survives, so a resized `Wear` is still round.
-`px` resolves against the form factor's density unless you pass another, and refuses a pixel size
-that does not land on a whole dp rather than quietly writing an image a pixel off.
-
-A custom `mockupFrame` is scaled to fit whatever canvas it lands on, the same as the built-in
-bezels, so the common `Modifier.fillMaxWidth().aspectRatio(…)` frame gets smaller on a short canvas
-instead of running off the bottom edge.
-
 Both are a scale model of a real iPhone. The enclosure, bezel, corner radii, Dynamic Island,
 side buttons and status bar were measured off an iPhone 17 running iOS 26.5 in the Xcode
 Simulator, and are drawn as a fixed fraction of the frame's width — so the phone stays in
@@ -220,6 +193,38 @@ iPad shows none), and the clock at the leading edge followed by the date rather 
 
 Apple form factors write to `{locale}/{subdir}/`, without the `images/` level Play uses — set
 `destDir` to `fastlane/screenshots` for them and `fastlane/metadata/android` for Play.
+
+### Changing the canvas size
+
+The sizes above are defaults, not requirements. Play documents a range — any portrait phone
+screenshot from 320px to 3840px, with the long side no more than twice the short side — and where
+you sit inside it is a design decision. Pass a `ScreenshotCanvas` to make it:
+
+```kotlin
+class HomeShots : StoreScreenshotsTest(
+    FormFactor.Phone,
+    canvas = ScreenshotCanvas.px(1080, 1920),   // 9:16 — .dp(414, 736) is the same shape, larger
+)
+```
+
+`Phone` defaults to **1242 x 2484 — exactly 1:2**, the tallest shape inside Play's documented range
+and so the one that leaves the device mockup largest. Be aware that the 2:1 limit is documented but
+not enforced at upload — taller images do go through the Publishing API today — so treat it as the
+range Play asks for rather than a gate that will stop a release.
+
+The requirement worth targeting deliberately is **promotional eligibility**, which is separate and
+stricter: at least four screenshots, 1080px or wider, at **9:16**. The 1:2 default does not meet it,
+since 9:16 is 1:1.78, and meeting it is a real trade rather than a free upgrade — at 9:16 there is
+much less height left beside the title and description, so the mockup shrinks by roughly a quarter
+and the shot reads emptier. Take it deliberately with `ScreenshotCanvas.px(1080, 1920)`.
+
+Only the size is replaced — every other qualifier survives, so a resized `Wear` is still round.
+`px` resolves against the form factor's density unless you pass another, and refuses a pixel size
+that does not land on a whole dp rather than quietly writing an image a pixel off.
+
+A custom `mockupFrame` is scaled to fit whatever canvas it lands on, the same as the built-in
+bezels, so the common `Modifier.fillMaxWidth().aspectRatio(…)` frame gets smaller on a short canvas
+instead of running off the bottom edge.
 
 ### Feature graphic
 
@@ -394,7 +399,7 @@ fun HomePreview() = ScreenshotPreview(
 
 | Annotation | Dimensions |
 | --- | --- |
-| `@PhoneScreenshotPreview` | 414 x 736 dp |
+| `@PhoneScreenshotPreview` | 414 x 828 dp |
 | `@WearScreenshotPreview` | 227 x 227 dp |
 | `@Tablet7ScreenshotPreview` | 600 x 960 dp |
 | `@Tablet10ScreenshotPreview` | 800 x 1280 dp |
@@ -748,7 +753,7 @@ To preview the whole un-sliced banner in Android Studio, render it at
 `widthDp = N × formFactorDp + (N − 1) × gap` with the seam marks on top:
 
 ```kotlin
-@Preview(widthDp = 1290, heightDp = 736) // 3 × 414dp + 2 × 24dp gap
+@Preview(widthDp = 1290, heightDp = 828) // 3 × 414dp + 2 × 24dp gap
 @Composable
 fun StoryPreview() = Box(Modifier.fillMaxSize()) {
     StoryBanner()

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/FormFactor.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/FormFactor.kt
@@ -25,17 +25,20 @@ enum class FormFactor(
      * Play Store phone screenshot. Portrait 1242x2484 — `414dp x 828dp` at xxhdpi (density 3.0),
      * exactly 1:2.
      *
-     * The canvas used to be `411dp x 914dp`, which renders 1233x2742 — a 1:2.22 image the Play
-     * Console turns away, since it rejects a screenshot whose long side is more than twice its
-     * short side. 1:2 is the tallest canvas that clears that rule, and it is deliberately the
-     * default because it is the one that changes the least: the phone mockup is limited by the
-     * canvas *width* here, exactly as it was at 1:2.22, so a shot keeps roughly the proportions it
-     * had before (device 321dp wide against 355dp, rather than the 275dp a 9:16 canvas forces).
+     * The canvas used to be `411dp x 914dp`, which renders 1233x2742 — a 1:2.22 image, past the
+     * maximum Play documents (long side no more than twice the short side). That limit is not
+     * enforced at upload, and listings do ship 1:2.22 phone screenshots today, so this is about
+     * staying inside the range Play asks for rather than clearing a gate that would block a
+     * release. 1:2 is the tallest canvas inside it, and it is deliberately the default because it
+     * is the one that changes the least: the phone mockup is limited by the canvas *width* here,
+     * exactly as it was at 1:2.22, so a shot keeps roughly the proportions it had before (device
+     * 321dp wide against 355dp, rather than the 275dp a 9:16 canvas forces).
      *
-     * Play separately asks for 9:16 portrait at 1080px or more to be eligible for promotion. That
-     * is a real trade rather than a strict improvement — at 9:16 there is not enough height left
-     * beside a title and description for the mockup, so the device shrinks by about a quarter and
-     * the shot reads emptier. It is one line away when a project wants it:
+     * Play separately asks for 9:16 portrait at 1080px or more to be eligible for promotion, and
+     * 1:2 does not satisfy that — 9:16 is 1:1.78. It is also a real trade rather than a strict
+     * improvement: at 9:16 there is not enough height left beside a title and description for the
+     * mockup, so the device shrinks by about a quarter and the shot reads emptier. It is one line
+     * away when a project wants it:
      *
      * ```kotlin
      * class HomeShots : StoreScreenshotsTest(

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotCanvas.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotCanvas.kt
@@ -6,12 +6,15 @@ import kotlin.math.roundToInt
  * An override for the canvas a form factor renders on, so a project is not stuck with the size
  * [FormFactor] ships as its default.
  *
- * Store requirements are a range, not a number — Play accepts any portrait phone screenshot from
- * 320px to 3840px as long as the long side is no more than twice the short side — and which point
- * in that range is right is a design decision, not a fact about the store. The default phone canvas
- * is 1:2 because it is the tallest legal shape and so the one that leaves the mockup largest; a
- * project that would rather be eligible for Play's promotional slots takes 9:16 and accepts a
- * smaller device:
+ * Store requirements are a range, not a number — Play documents portrait phone screenshots from
+ * 320px to 3840px with the long side no more than twice the short side — and which point in that
+ * range is right is a design decision, not a fact about the store. The default phone canvas is 1:2
+ * because it is the tallest shape inside that range and so the one that leaves the mockup largest.
+ * (The 2:1 maximum is documented but not enforced at upload; taller images do go through today.)
+ *
+ * The requirement worth opting into deliberately is promotional eligibility, which is separate and
+ * stricter — at least four screenshots, 1080px or wider, at 9:16. The 1:2 default does not meet it,
+ * so a project that wants Play's promotional slots takes 9:16 and accepts a smaller device:
  *
  * ```kotlin
  * class HomeShots : StoreScreenshotsTest(

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/ScreenshotRule.kt
@@ -422,7 +422,7 @@ private fun panelWidthDp(qualifiers: String): Int =
  * Widens the `wNNNdp` width in a Robolectric [qualifiers] string to hold [panels] panels plus
  * [gapDp] dp between each, leaving the height and density buckets untouched — so the canvas is the
  * full split width at the form factor's normal height and pixel density.
- * e.g. `w414dp-h736dp-xxhdpi`, 3 panels, 24dp gap → `w1290dp-h736dp-xxhdpi` (414×3 + 24×2).
+ * e.g. `w414dp-h828dp-xxhdpi`, 3 panels, 24dp gap → `w1290dp-h828dp-xxhdpi` (414×3 + 24×2).
  */
 private fun widenQualifiers(qualifiers: String, panels: Int, gapDp: Int): String =
     Regex("""w(\d+)dp""").replace(qualifiers) { match ->

--- a/library/src/main/kotlin/dev/lucianosantos/storescreenshots/SplitSeams.kt
+++ b/library/src/main/kotlin/dev/lucianosantos/storescreenshots/SplitSeams.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.unit.dp
  * be baked into the exported PNGs. Pass the same [count] and [gap] you give `splitScreenshot`.
  *
  * ```kotlin
- * @Preview(widthDp = 1290, heightDp = 736)   // 3 × 414dp + 2 × 24dp gap
+ * @Preview(widthDp = 1290, heightDp = 828)   // 3 × 414dp + 2 × 24dp gap
  * @Composable fun StoryPreview() = Box(Modifier.fillMaxSize()) {
  *     StoryBanner()
  *     SplitSeams(count = 3, gap = 24.dp)   // shades the two discarded gap strips

--- a/library/src/test/kotlin/dev/lucianosantos/storescreenshots/FormFactorSizeTest.kt
+++ b/library/src/test/kotlin/dev/lucianosantos/storescreenshots/FormFactorSizeTest.kt
@@ -1,6 +1,7 @@
 package dev.lucianosantos.storescreenshots
 
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 /**
@@ -44,15 +45,19 @@ class FormFactorSizeTest {
     }
 
     /**
-     * Play turns away any screenshot whose long side is more than twice its short side — the bug
-     * that sent the phone canvas back at 1233x2742 (1:2.22).
+     * Play documents a maximum dimension no more than twice the minimum, which the old phone
+     * canvas missed at 1233x2742 (1:2.22).
+     *
+     * The limit is documented but **not enforced at upload** — images past it do go through the
+     * Publishing API today, and shipping listings carry 1:2.22 phone screenshots. So this pins us
+     * inside the range Play asks for; it is not a gate that would otherwise fail a release.
      *
      * Only the Play *screenshot* slots are held to it. The App Store sets its own dimensions and
      * several of them are past 1:2 by Apple's own mandate (iPhone 6.7" is 1290x2796, 1:2.17), and
      * the feature graphic is a fixed 1024x500 promotional banner, not a screenshot.
      */
     @Test
-    fun noPlayScreenshotIsTooElongatedForPlayToAccept() {
+    fun everyPlayScreenshotIsWithinPlaysDocumentedAspectLimit() {
         val playScreenshots = listOf(
             FormFactor.Phone,
             FormFactor.Wear,
@@ -62,11 +67,10 @@ class FormFactorSizeTest {
         for (formFactor in playScreenshots) {
             val longest = maxOf(formFactor.widthPx, formFactor.heightPx)
             val shortest = minOf(formFactor.widthPx, formFactor.heightPx)
-            assertEquals(
+            assertTrue(
                 "${formFactor.name} is ${formFactor.widthPx}x${formFactor.heightPx}, a " +
-                    "1:${"%.2f".format(longest.toFloat() / shortest)} image — Play rejects " +
-                    "anything past 1:2",
-                true,
+                    "1:${"%.2f".format(longest.toFloat() / shortest)} image — past the 1:2 " +
+                    "maximum Play documents",
                 longest <= shortest * 2,
             )
         }
@@ -126,22 +130,22 @@ class FormFactorSizeTest {
     }
 
     /**
-     * The default phone canvas sits exactly on the 1:2 limit — the tallest shape Play accepts, and
-     * so the one that leaves the mockup largest, which is why it is the default rather than the
-     * 9:16 that Play's promotional guidance prefers. 9:16 costs about a quarter of the device's
-     * width, and a project that wants that trade makes it explicitly through [ScreenshotCanvas].
+     * The default phone canvas sits exactly on the 1:2 limit — the tallest shape inside Play's
+     * documented range, and so the one that leaves the mockup largest, which is why it is the
+     * default rather than the 9:16 that Play's promotional guidance prefers. 9:16 costs about a
+     * quarter of the device's width, and a project that wants that trade makes it explicitly
+     * through [ScreenshotCanvas].
      *
-     * Pinned to the pixel because it is a boundary: anything taller is rejected outright, so this
-     * is the one size where drifting by a single pixel is the difference between a listing that
-     * uploads and one that does not.
+     * Pinned to the pixel because 1:2 is the edge of the documented range and the reason this
+     * default was chosen over any other. Note it does *not* satisfy promotional eligibility, which
+     * asks for 9:16 — that is a separate, deliberate opt-in.
      */
     @Test
     fun theDefaultPhoneCanvasIsExactlyOneByTwoAndWideEnoughForEveryPlayFloor() {
         val (width, height) = FormFactor.Phone.widthPx to FormFactor.Phone.heightPx
         assertEquals("the default phone canvas must be exactly 1:2", 2 * width, height)
-        assertEquals(
+        assertTrue(
             "phone screenshots must be at least 1080px wide to clear Play's floors, was $width",
-            true,
             width >= 1080,
         )
     }
@@ -190,9 +194,8 @@ class FormFactorSizeTest {
         val error = org.junit.Assert.assertThrows(IllegalArgumentException::class.java) {
             FormFactor.Phone.qualifiersWith(ScreenshotCanvas.px(1000, 2000))
         }
-        assertEquals(
-            "the message should name the axis and the size actually rendered",
-            true,
+        assertTrue(
+            "the message should name the axis and the size actually rendered, was: ${error.message}",
             error.message!!.contains("333dp") && error.message!!.contains("999px"),
         )
     }


### PR DESCRIPTION
Follow-up to #12. Text only — no behaviour changes. All 15 library tests pass and both frame goldens still match byte-for-byte, so nothing here moves a pixel.

### The rationale was wrong

#12 justified the new canvas by saying Play rejects a screenshot whose long side is more than twice its short side. Play does [document that maximum](https://support.google.com/googleplay/android-developer/answer/9866151) — *"The maximum dimension of your screenshot can't be more than twice as long as the minimum dimension"* — but it is **not enforced at upload**.

Two of my published apps ship phone screenshots at the old 1233x2742 (1:2.224, past the limit) and both upload through `fastlane supply` without complaint:

| App | Phone screenshots | Ratio | Result |
| --- | --- | --- | --- |
| Interval Timer | 1233x2742, 5 shots × ~30 locales | 1:2.224 | uploads fine |
| LG Remote | 1233x2742, 4 shots × ~30 locales | 1:2.224 | uploads fine |

So 1:2 is worth having as the shape we sit at inside the documented range, but it was never the difference between a listing that uploads and one that does not — and the `FormFactor` KDoc, the `ScreenshotCanvas` KDoc, the README and a test name all said that it was.

Reworded to say what is true. `noPlayScreenshotIsTooElongatedForPlayToAccept` becomes `everyPlayScreenshotIsWithinPlaysDocumentedAspectLimit`, which is what it actually checks.

The same passages now also say plainly that **1:2 does not satisfy promotional eligibility** — the criterion that does pay out, at four screenshots, 1080px or wider, at 9:16. 9:16 is 1:1.78, so the default meets neither the promotional bar nor a hard requirement, and a reader weighing 1:2 against 9:16 had no way to tell that from the old text.

### The docs still quoted the abandoned 9:16 draft

The phone canvas landed on 414x828dp, but four places were still quoting the 414x736dp from the 9:16 draft that preceded it:

- `README.md` — the `@PhoneScreenshotPreview` row in the preview table
- `README.md` — the split-banner `@Preview` example
- `SplitSeams.kt` — the same example in its KDoc
- `ScreenshotRule.kt` — `widenQualifiers`' worked example, on both sides of the arrow

The example project's own `@Preview` **was** updated to 828 at the time, so the docs had drifted away from the code they document — the exact failure #12 set out to end. `FormFactorSizeTest` can't catch this class of drift: it holds Kotlin constants against the qualifiers, and these are prose.

(The three remaining `736`s in the tree are correct — they describe the 9:16 override, which genuinely is 414x736dp at 1242px wide.)

### While in there

`README.md` — the `### Changing the canvas size` section had been inserted between the Apple-frames paragraph and the sentence that continues it, stranding *"**Both** are a scale model of a real iPhone…"* 27 lines from the `AppleIPhone67`/`AppleIPhone65` it refers to, and nesting the whole iPhone/iPad frame block under a heading about canvas sizing. Moved down to sit between the Apple frames and `### Feature graphic`.

`FormFactorSizeTest` — three `assertEquals(msg, true, cond)` become `assertTrue(msg, cond)`, so a failure reports the carefully-written message instead of `expected:<true> but was:<false>`.

### Verification

`:library:testDebugUnitTest` with `--rerun-tasks` on JDK 17: 15 tests, all green.

```
phone_frame.png vs the frame as rendered now
  differing pixels   0 of 3,085,128 (0.0000%, max 0.2000%)
  mean channel error 0.0000 (max 1.0000)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)