### PR TITLE
Follow up on the screenshots/res move: exemplar, warning, flavors

### DIFF
--- a/README.md
+++ b/README.md
@@ -441,11 +441,36 @@ Two consequences worth knowing:
 - **Debug resources override `main`.** A name that exists in both silently wins in every debug
   build. Prefix listing strings (`screenshot_…`) so they can't collide with production copy.
 - **Only `src/debug/` and `src/screenshots/` can read them.** A composable in `src/main/` that
-  references one won't compile in a release build. Pass the text in as a parameter instead — see
-  [`FeatureGraphicBanner`](example/src/main/kotlin/dev/lucianosantos/storescreenshots/example/FeatureGraphicBanner.kt).
+  references one won't compile in a release build. Take the copy as a parameter and let the caller
+  in `src/screenshots/` resolve it:
+
+  ```kotlin
+  // src/main — no R.string reference, so it compiles in every variant.
+  @Composable
+  fun Banner(title: String, description: String? = null) { /* … */ }
+
+  // src/screenshots — resolves the debug-only strings and passes them down.
+  customScreenshot(fileName = "banner") {
+      Banner(
+          title = stringResource(R.string.screenshot_banner_title),
+          description = stringResource(R.string.screenshot_banner_desc),
+      )
+  }
+  ```
+
+  [`FeatureGraphicBanner`](example/src/main/kotlin/dev/lucianosantos/storescreenshots/example/FeatureGraphicBanner.kt)
+  is written this way. Note it still isn't release-compilable, for an unrelated reason — it draws
+  `DeviceMockup`s, and this library is a `testImplementation`/`debugImplementation` dependency of
+  the example. Parameterizing the copy is what keeps the *strings* out of `src/main`; a composable
+  that also needs library types stays debug-only regardless.
 
 The frame images for [image mockups](#where-to-put-the-frame-image) work the same way, but go in
 `src/screenshots/resources/` and load from the classpath.
+
+> **Plain `debug` build type, no product flavors.** Both the `storeScreenshots` task (which runs
+> `testDebugUnitTest`) and the `src/screenshots/res` registration name `debug` directly rather than
+> reading `testBuildType`. On a module with product flavors the task is `testFreeDebugUnitTest` and
+> neither holds, so screenshot generation is not supported there yet.
 
 ## Examples
 

--- a/plugin/src/main/kotlin/dev/lucianosantos/storescreenshots/gradle/StoreScreenshotsPlugin.kt
+++ b/plugin/src/main/kotlin/dev/lucianosantos/storescreenshots/gradle/StoreScreenshotsPlugin.kt
@@ -26,6 +26,12 @@ import java.util.Properties
  *    produced them.
  * 6. Registers a `storeScreenshots` task in the host module that runs `testDebugUnitTest`
  *    and is the recommended entry point.
+ *
+ * **The host module is assumed to have a plain `debug` build type and no product flavors.** Both
+ * the `storeScreenshots` task (which depends on `testDebugUnitTest`) and the `src/screenshots/res`
+ * registration name `debug` directly rather than reading `testBuildType`. With product flavors the
+ * task is `testFreeDebugUnitTest` and neither holds, so screenshot generation is not supported on
+ * a flavored module today.
  */
 class StoreScreenshotsPlugin : Plugin<Project> {
     override fun apply(target: Project) {
@@ -101,12 +107,24 @@ class StoreScreenshotsPlugin : Plugin<Project> {
         // under test and never merges the `test` source set's own res/, so anything declared
         // there would compile to nothing. Debug also keeps the strings out of the released APK
         // while making them visible to the @Preview functions `debugImplementation` wires up.
+        //
+        // `debug` is assumed rather than read from `testBuildType`, the same assumption the
+        // `storeScreenshots` task already makes by depending on `testDebugUnitTest`. A project
+        // with product flavors or a different test build type is not supported either way.
+        //
+        // A missing `debug` build type only costs the listing strings, and the rest of the plugin
+        // still does its job, so it warns rather than failing the whole configuration phase for a
+        // project that applied the plugin but never runs it.
         val debugSourceSet = common.sourceSets.findByName("debug")
-            ?: error(
-                "store-screenshots needs a `debug` build type on project ${target.path} to host " +
-                    "src/screenshots/res, but none exists."
+        if (debugSourceSet != null) {
+            debugSourceSet.res.directories.add("src/screenshots/res")
+        } else {
+            target.logger.warn(
+                "store-screenshots: project ${target.path} has no `debug` build type, so " +
+                    "src/screenshots/res was not registered. Listing strings referenced as " +
+                    "titleRes/descriptionRes will not resolve."
             )
-        debugSourceSet.res.directories.add("src/screenshots/res")
+        }
 
         common.testOptions.unitTests.apply {
             isIncludeAndroidResources = true


### PR DESCRIPTION
Follow-up to #9, from the review. Three points, none of which change what the plugin does on a project that has a `debug` build type.

### The README pointed at an exemplar that doesn't demonstrate the pattern

The new section told readers:

> A composable in `src/main/` that references one won't compile in a release build. Pass the text in as a parameter instead — see `FeatureGraphicBanner`.

But `FeatureGraphicBanner` doesn't compile in a release build either. `:example:compileReleaseKotlin` fails on it with 36 unresolved references:

```
e: .../FeatureGraphicBanner.kt:25:43 Unresolved reference 'DeviceMockup'.
e: .../FeatureGraphicBanner.kt:26:43 Unresolved reference 'FormFactor'.
e: .../FeatureGraphicBanner.kt:27:43 Unresolved reference 'WatchMockup'.
...
```

It draws `DeviceMockup`s, and this library is a `testImplementation`/`debugImplementation` dependency of the example — so the file is debug-only no matter where its strings live. **This is pre-existing**, not something #9 introduced (I confirmed the identical 36 errors on `main` before #9), but it makes a confusing exemplar: a reader who follows the link to watch the pattern pay off finds a file that doesn't build in release for an unrelated reason.

The advice now carries a self-contained before/after snippet, and says plainly that the example stays debug-only regardless and that parameterizing the copy is about the *strings* specifically.

### A missing `debug` build type failed the configuration phase

`findByName("debug") ?: error(…)` meant a project that applied the plugin without a `debug` build type couldn't configure at all, even if it never invoked `storeScreenshots`. Only the listing strings depend on it — everything else the plugin does still works — so it now warns and skips.

Nothing that worked stops working: such a project could never run the task anyway, since `storeScreenshots` depends on `testDebugUnitTest`.

### The flavors limitation is now written down

`debug` is named directly in two places now, and neither reads `testBuildType`, so a module with product flavors is unsupported — the task would be `testFreeDebugUnitTest` and the build-type source set wouldn't be plain `debug`. That limitation already existed and was undocumented. It's now stated in the plugin KDoc and in the README.

### Verification

`:plugin:compileKotlin`, `:example:testDebugUnitTest` (38 tests) and `:library:testDebugUnitTest` (15 tests) all pass.

The no-`debug`-build-type branch is reasoned about rather than exercised — there's no fixture for a module without one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)