### PR TITLE
Stop pinning a plugin version the README cannot keep current

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ pluginManagement {
         mavenCentral()
     }
     plugins {
-        id("io.github.lucianosantosdev.storescreenshots") version "1.4.5"
+        id("io.github.lucianosantosdev.storescreenshots") version "<version>"
     }
 }
 
@@ -55,6 +55,8 @@ dependencyResolutionManagement {
     }
 }
 ```
+
+Replace `<version>` with the current release — the [![Maven Central](https://img.shields.io/maven-central/v/io.github.lucianosantosdev/storescreenshots-plugin?label=)](https://central.sonatype.com/artifact/io.github.lucianosantosdev/storescreenshots-plugin) badge above always shows it.
 
 The plugin resolves its runtime library (`io.github.lucianosantosdev:storescreenshots-library`) automatically — you only declare the plugin id.
 


### PR DESCRIPTION
The install snippet quoted `version "1.4.5"`. Releases have moved past it — and every future release moves past whatever it is replaced with. A version in prose is stale the moment it is written, and a copy-pasted stale one resolves an old plugin against a current library.

The Maven Central badge at the top of the page already renders the latest release, so the snippet points there instead of naming a number:

```kotlin
id("io.github.lucianosantosdev.storescreenshots") version "<version>"
```

> Replace `<version>` with the current release — the Maven Central badge above always shows it.

Docs only. Split out from #16 so it can merge without waiting on that review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)